### PR TITLE
fix: dev: ModuleNotFoundError

### DIFF
--- a/flask_reverse_proxy_fix/middleware/__init__.py
+++ b/flask_reverse_proxy_fix/middleware/__init__.py
@@ -1,6 +1,9 @@
 from flask import Flask as App
 # noinspection PyPackageRequirements
-from werkzeug.contrib.fixers import ProxyFix
+try:
+    from werkzeug.contrib.fixers import ProxyFix
+except ModuleNotFoundError:
+    from werkzeug.middleware.proxy_fix import ProxyFix
 
 
 class ReverseProxyPrefixFix(object):


### PR DESCRIPTION
since werkzeug v1.0.0 ProxyFix is not on werkzeug.contrib.fixers instead on werkzeug.middleware.proxy_fix

this fix is based on following commit 

https://github.com/asciimoo/searx/commit/b8b13372c8fd3bfe978a1c724ab98b05348df054